### PR TITLE
Install pipeline from commit SHA

### DIFF
--- a/docs/managing_pipelines.md
+++ b/docs/managing_pipelines.md
@@ -68,6 +68,11 @@ Use `--tag` to specify the tag (version) of the pipeline to install. You can spe
 snk install --tag v1.0 Wytamma/snk-basic-pipeline && my-pipeline -v
 ```
 
+Use `--commit` to specify the commit (SHA) of the pipeline to install. If not specified, the latest commit will be installed.
+```bash
+snk install --commit a725d3a4 Wytamma/snk-basic-pipeline && snk-basic-pipeline -v
+```
+
 Use `--config` to install a pipeline with a non-standard config location. This is useful for installing a pipeline that does not follow Snakemake best practices. 
 ```bash
 snk install --config /path/to/config Wytamma/snk-basic-pipeline

--- a/snk/cli/cli.py
+++ b/snk/cli/cli.py
@@ -48,7 +48,10 @@ class CLI(DynamicTyper):
         if self.snk_config.version:
             self.version = self.snk_config.version
         else: 
-            self.version = self.pipeline.tag # git tag or null
+            if self.pipeline.tag:
+               self.version = self.pipeline.tag
+            else:
+                self.version = self.pipeline.commit
         self.options = build_dynamic_cli_options(self.snakemake_config, self.snk_config)
         self.snakefile = self._find_snakefile()
         self.conda_prefix_dir = pipeline_dir_path / ".conda"

--- a/snk/main.py
+++ b/snk/main.py
@@ -70,6 +70,12 @@ def install(
         "-t",
         help="Tag (version) of the pipeline to install. Can specify a branch name, or tag. If None the latest commit will be installed.",
     ),
+    commit: Optional[str] = typer.Option(
+        None,
+        "--commit",
+        "-c",
+        help="Commit (SHA) of the pipeline to install. If None the latest commit will be installed.",
+    ),
     config: Optional[Path] = typer.Option(
         None, help="Specify a non-standard config location."
     ),
@@ -102,6 +108,7 @@ def install(
             editable=editable,
             name=name,
             tag=tag,
+            commit=commit,
             config=config,
             additional_resources=resource,
             force=force,

--- a/snk/pipeline.py
+++ b/snk/pipeline.py
@@ -50,6 +50,20 @@ class Pipeline:
         return tag
     
     @property
+    def commit(self):
+        """
+        Gets the commit SHA of the pipeline.
+        Returns:
+            str: The commit SHA of the pipeline.
+        """
+        try:
+            sha = self.repo.head.object.hexsha
+            commit = self.repo.git.rev_parse(sha, short=8)
+        except Exception:
+           commit = None
+        return commit
+
+    @property
     def version(self):
         """
         Gets the version of the pipeline.
@@ -58,6 +72,8 @@ class Pipeline:
         """
         if (self.path / "snk.yaml").exists():
             version = get_version_from_config(self.path / "snk.yaml")
+        elif not self.tag:
+            version = self.commit
         else:
             version = self.tag
         return version if version else "latest"


### PR DESCRIPTION
Hello, thank you for this awesome tool! Would you have any interest in adding a `--commit` parameter to install pipelines based on a commit SHA? For example, the [Nextstrain](https://github.com/nextstrain) pipelines either have [infrequent tagged releases](https://github.com/nextstrain/ncov/tags), or [don't use tags at all](https://github.com/nextstrain/seasonal-flu/tags). Using the commit SHA would also bring `snk` closer to Nextflow's system for [precise revisioning](https://www.nextflow.io/docs/latest/sharing.html#handling-revisions).

This pull request includes some ideas for implementation and documentation updates. If you're not interested in this feature (or think it's problematic), feel free to close!

Example: [nextstrain/ncov](https://github.com/nextstrain/ncov) pipeline on commit [781da4af](https://github.com/nextstrain/ncov/tree/781da4af75b5d88a5248161c8ab70abe840194f8)

```bash
> snk install nextstrain/ncov --commit 781da4af
Successfully installed ncov (781da4af)!
```