### PR TITLE
JOSS review: Fix contributing typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ This document outlines the process and guidelines for contributing to the projec
 
 ## Code of Conduct
 
-Please note that this project follows a [Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project, you agree to abide by its terms. Be respectful to others in all interactions.
+Please note that this project follows a [Code of Conduct](https://github.com/Wytamma/snk?tab=coc-ov-file#readme). By participating in this project, you agree to abide by its terms. Be respectful to others in all interactions.
 
 ## A note on Snk vs Snk-CLI
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ git checkout -b feature/your-feature-name
 Before submitting your changes, make sure all tests pass:
 
 ```bash
-hatch runt test
+hatch run test
 ```
 
 To run tests with coverage:


### PR DESCRIPTION
Fixes a couple of minor typos found while reviewing the contributing guide.

Motivated by https://github.com/openjournals/joss-reviews/issues/7410